### PR TITLE
ci: run on Blacksmith runners

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   check:
     name: Test and lint
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 30
 
     steps:


### PR DESCRIPTION
Swap CI from GitHub-hosted `ubuntu-latest` to self-hosted `blacksmith-4vcpu-ubuntu-2404` so runs don't bill GitHub Actions minutes — matching the convention across the neutralbase org. (From a fork; opened for your review — not merging.)