### PR TITLE
feat(toolCosts): idempotent recomputeToolCostsByProviderAndTool

### DIFF
--- a/src/component/toolCosts.ts
+++ b/src/component/toolCosts.ts
@@ -2,6 +2,7 @@ import { v } from "convex/values";
 import {
   actionGeneric,
   internalMutationGeneric,
+  mutationGeneric,
   queryGeneric,
 } from "convex/server";
 import { api, internal } from "./_generated/api.js";
@@ -156,6 +157,116 @@ export const saveToolCost = internalMutationGeneric({
     });
 
     return costPerToolId;
+  },
+});
+
+/**
+ * Idempotently recompute stored tool-cost rows for a provider (and optional
+ * tool) from each row's stored `usage` and the CURRENT tool pricing. Used to
+ * correct historical rows that were written under a since-fixed pricing rate
+ * (e.g. a 10x-inflated per-credit rate). Re-running is a no-op once rows
+ * already match current pricing, so it is safe to run repeatedly.
+ *
+ * Paginated: processes one page and returns a cursor so the caller can loop
+ * over the full set. `dryRun` reports what would change without writing.
+ *
+ * @returns Per-page stats: rows scanned/changed, raw-cost amount before/after.
+ */
+export const recomputeToolCostsByProviderAndTool = mutationGeneric({
+  args: {
+    providerId: v.string(),
+    toolId: v.optional(v.string()),
+    cursor: v.optional(v.union(v.string(), v.null())),
+    numItems: v.optional(v.number()),
+    dryRun: v.optional(v.boolean()),
+  },
+  handler: async (ctx, args) => {
+    const numItems = Math.max(1, Math.min(args.numItems ?? 200, 500));
+    const dryRun = args.dryRun ?? false;
+
+    const page = await (args.toolId
+      ? ctx.db
+          .query("costPerTools")
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          .withIndex("by_provider_and_tool", (q: any) =>
+            q.eq("providerId", args.providerId).eq("toolId", args.toolId),
+          )
+      : ctx.db
+          .query("costPerTools")
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          .withIndex("by_provider", (q: any) =>
+            q.eq("providerId", args.providerId),
+          )
+    ).paginate({ cursor: args.cursor ?? null, numItems });
+
+    let scanned = 0;
+    let changed = 0;
+    let skippedNoPricing = 0;
+    let skippedError = 0;
+    let amountBefore = 0;
+    let amountAfter = 0;
+
+    for (const row of page.page) {
+      scanned += 1;
+      amountBefore += row.cost.amount;
+
+      const pricing = await ctx.db
+        .query("toolsPricing")
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        .withIndex("by_provider_and_tool", (q: any) =>
+          q.eq("providerId", row.providerId).eq("toolId", row.toolId),
+        )
+        .first();
+
+      if (!pricing) {
+        skippedNoPricing += 1;
+        amountAfter += row.cost.amount;
+        continue;
+      }
+
+      // Preserve the markup the row was originally written with: the raw
+      // `cost` axis is what an inflated rate corrupts, and `costForUser`
+      // scales with the same multiplier.
+      const markup = row.costForUser.markupMultiplier ?? 1;
+
+      let recomputed: CalculatedToolCost;
+      try {
+        recomputed = calculateToolCost(
+          row.usage,
+          pricing.pricing as ToolPricing,
+          markup,
+        );
+      } catch {
+        // Usage/pricing type mismatch for this row — leave it untouched.
+        skippedError += 1;
+        amountAfter += row.cost.amount;
+        continue;
+      }
+
+      amountAfter += recomputed.cost.amount;
+
+      if (recomputed.cost.amount !== row.cost.amount) {
+        changed += 1;
+        if (!dryRun) {
+          await ctx.db.patch(row._id, {
+            cost: recomputed.cost,
+            costForUser: recomputed.costForUser,
+          });
+        }
+      }
+    }
+
+    return {
+      scanned,
+      changed,
+      skippedNoPricing,
+      skippedError,
+      amountBefore: Math.round(amountBefore * 1e8) / 1e8,
+      amountAfter: Math.round(amountAfter * 1e8) / 1e8,
+      dryRun,
+      continueCursor: page.isDone ? null : page.continueCursor,
+      isDone: page.isDone,
+    };
   },
 });
 

--- a/src/component/toolCosts.ts
+++ b/src/component/toolCosts.ts
@@ -160,6 +160,140 @@ export const saveToolCost = internalMutationGeneric({
   },
 });
 
+type RecomputeToolCostCursor = {
+  version: 1;
+  creationTime: number;
+  seenIds: string[];
+};
+
+type RecomputeToolCostMutationCtx = {
+  db: {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    query: (tableName: "costPerTools") => any;
+  };
+};
+
+function parseRecomputeToolCostCursor(
+  cursor: string | null | undefined,
+): RecomputeToolCostCursor | null {
+  if (!cursor) {
+    return null;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(cursor);
+  } catch {
+    throw new Error("Invalid recompute tool-cost cursor: malformed JSON");
+  }
+
+  if (parsed === null || typeof parsed !== "object") {
+    throw new Error("Invalid recompute tool-cost cursor");
+  }
+
+  const typed = parsed as Partial<RecomputeToolCostCursor>;
+  if (
+    typed.version !== 1 ||
+    typeof typed.creationTime !== "number" ||
+    !Number.isFinite(typed.creationTime) ||
+    !Array.isArray(typed.seenIds) ||
+    !typed.seenIds.every((id) => typeof id === "string")
+  ) {
+    throw new Error("Invalid recompute tool-cost cursor");
+  }
+
+  return {
+    version: 1,
+    creationTime: typed.creationTime,
+    seenIds: typed.seenIds,
+  };
+}
+
+function encodeRecomputeToolCostCursor(
+  rows: Array<Doc<"costPerTools">>,
+  previous: RecomputeToolCostCursor | null,
+): string | null {
+  const lastRow = rows[rows.length - 1];
+  if (!lastRow) {
+    return null;
+  }
+
+  const lastCreationTime = lastRow._creationTime;
+  const seenIds =
+    previous !== null && previous.creationTime === lastCreationTime
+      ? [...previous.seenIds]
+      : [];
+  const seenIdSet = new Set(seenIds);
+
+  for (const row of rows) {
+    if (row._creationTime !== lastCreationTime || seenIdSet.has(row._id)) {
+      continue;
+    }
+    seenIds.push(row._id);
+    seenIdSet.add(row._id);
+  }
+
+  return JSON.stringify({
+    version: 1,
+    creationTime: lastCreationTime,
+    seenIds,
+  } satisfies RecomputeToolCostCursor);
+}
+
+async function getRecomputeToolCostPage(
+  ctx: RecomputeToolCostMutationCtx,
+  args: { providerId: string; toolId?: string; cursor?: string | null },
+  numItems: number,
+): Promise<{
+  rows: Array<Doc<"costPerTools">>;
+  continueCursor: string | null;
+  isDone: boolean;
+}> {
+  const cursor = parseRecomputeToolCostCursor(args.cursor);
+  const seenIds = new Set(cursor?.seenIds ?? []);
+  const queryLimit = numItems + seenIds.size + 1;
+  const candidateRows = await (args.toolId
+    ? ctx.db
+        .query("costPerTools")
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        .withIndex("by_provider_and_tool", (q: any) => {
+          const range = q
+            .eq("providerId", args.providerId)
+            .eq("toolId", args.toolId);
+          return cursor === null
+            ? range
+            : range.gte("_creationTime", cursor.creationTime);
+        })
+    : ctx.db
+        .query("costPerTools")
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        .withIndex("by_provider", (q: any) => {
+          const range = q.eq("providerId", args.providerId);
+          return cursor === null
+            ? range
+            : range.gte("_creationTime", cursor.creationTime);
+        })
+  ).take(queryLimit);
+
+  const rowsWithLookahead =
+    cursor === null
+      ? candidateRows
+      : candidateRows.filter(
+          (row: Doc<"costPerTools">) =>
+            row._creationTime > cursor.creationTime || !seenIds.has(row._id),
+        );
+  const rows = rowsWithLookahead.slice(0, numItems);
+  const isDone = rowsWithLookahead.length <= numItems;
+
+  return {
+    rows,
+    continueCursor: isDone
+      ? null
+      : encodeRecomputeToolCostCursor(rows, cursor),
+    isDone,
+  };
+}
+
 /**
  * Idempotently recompute stored tool-cost rows for a provider (and optional
  * tool) from each row's stored `usage` and the CURRENT tool pricing. Used to
@@ -167,8 +301,9 @@ export const saveToolCost = internalMutationGeneric({
  * (e.g. a 10x-inflated per-credit rate). Re-running is a no-op once rows
  * already match current pricing, so it is safe to run repeatedly.
  *
- * Paginated: processes one page and returns a cursor so the caller can loop
- * over the full set. `dryRun` reports what would change without writing.
+ * Processes one bounded page and returns a component-safe cursor so the caller
+ * can loop over the full set. `dryRun` reports what would change without
+ * writing.
  *
  * @returns Per-page stats: rows scanned/changed, raw-cost amount before/after.
  */
@@ -180,24 +315,21 @@ export const recomputeToolCostsByProviderAndTool = mutationGeneric({
     numItems: v.optional(v.number()),
     dryRun: v.optional(v.boolean()),
   },
+  returns: v.object({
+    scanned: v.number(),
+    changed: v.number(),
+    skippedNoPricing: v.number(),
+    skippedError: v.number(),
+    amountBefore: v.number(),
+    amountAfter: v.number(),
+    dryRun: v.boolean(),
+    continueCursor: v.union(v.string(), v.null()),
+    isDone: v.boolean(),
+  }),
   handler: async (ctx, args) => {
     const numItems = Math.max(1, Math.min(args.numItems ?? 200, 500));
     const dryRun = args.dryRun ?? false;
-
-    const page = await (args.toolId
-      ? ctx.db
-          .query("costPerTools")
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          .withIndex("by_provider_and_tool", (q: any) =>
-            q.eq("providerId", args.providerId).eq("toolId", args.toolId),
-          )
-      : ctx.db
-          .query("costPerTools")
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          .withIndex("by_provider", (q: any) =>
-            q.eq("providerId", args.providerId),
-          )
-    ).paginate({ cursor: args.cursor ?? null, numItems });
+    const page = await getRecomputeToolCostPage(ctx, args, numItems);
 
     let scanned = 0;
     let changed = 0;
@@ -205,18 +337,28 @@ export const recomputeToolCostsByProviderAndTool = mutationGeneric({
     let skippedError = 0;
     let amountBefore = 0;
     let amountAfter = 0;
+    const pricingCache = new Map<string, Doc<"toolsPricing"> | null>();
 
-    for (const row of page.page) {
+    for (const row of page.rows) {
       scanned += 1;
       amountBefore += row.cost.amount;
 
-      const pricing = await ctx.db
-        .query("toolsPricing")
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        .withIndex("by_provider_and_tool", (q: any) =>
-          q.eq("providerId", row.providerId).eq("toolId", row.toolId),
-        )
-        .first();
+      const pricingCacheKey = `${row.providerId}:${row.toolId}`;
+      const cachedPricing = pricingCache.get(pricingCacheKey);
+      let pricing: Doc<"toolsPricing"> | null;
+      if (cachedPricing !== undefined) {
+        pricing = cachedPricing;
+      } else {
+        pricing =
+          (await ctx.db
+            .query("toolsPricing")
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            .withIndex("by_provider_and_tool", (q: any) =>
+              q.eq("providerId", row.providerId).eq("toolId", row.toolId),
+            )
+            .first()) ?? null;
+        pricingCache.set(pricingCacheKey, pricing);
+      }
 
       if (!pricing) {
         skippedNoPricing += 1;
@@ -237,7 +379,7 @@ export const recomputeToolCostsByProviderAndTool = mutationGeneric({
           markup,
         );
       } catch {
-        // Usage/pricing type mismatch for this row — leave it untouched.
+        // Usage/pricing type mismatch for this row: leave it untouched.
         skippedError += 1;
         amountAfter += row.cost.amount;
         continue;
@@ -264,7 +406,7 @@ export const recomputeToolCostsByProviderAndTool = mutationGeneric({
       amountBefore: Math.round(amountBefore * 1e8) / 1e8,
       amountAfter: Math.round(amountAfter * 1e8) / 1e8,
       dryRun,
-      continueCursor: page.isDone ? null : page.continueCursor,
+      continueCursor: page.continueCursor,
       isDone: page.isDone,
     };
   },


### PR DESCRIPTION
## Summary
Adds `recomputeToolCostsByProviderAndTool` to the component's `toolCosts` module — a paginated, idempotent maintenance mutation that recomputes stored `costPerTools` rows from each row's own `usage` × the **current** tool pricing.

## Why
The component exposes `addToolCost` + read queries but no way to correct rows already written under a since-fixed pricing rate. A consumer (BRG) recorded credit-priced Scrapfly COGS at a 10×-inflated per-credit rate; the rate is now fixed for new rows, but historical rows stay inflated and there is no supported path to repair them in place. This adds that path generically.

## Design
- Reuses the component's own `calculateToolCost(usage, pricing, markup)` so corrected values match exactly how `addToolCost` would have written them.
- **Idempotent**: recomputes from `usage` × current pricing and only patches when the amount differs, so re-running after rows already match is a no-op (no blind ×factor that double-applies).
- Preserves each row's original markup (`costForUser.markupMultiplier`), so only the raw rate correction flows through; `costForUser` scales with the same multiplier.
- Paginated (`cursor`/`numItems`, capped 500/page) so the caller loops over large sets; `dryRun` reports `scanned`/`changed`/`amountBefore`/`amountAfter` without writing.
- Rows whose `usage`/pricing type mismatch, or that have no current pricing, are skipped and counted, never corrupted.

## Validation
Local build + typecheck + vitest (component test suite). No schema change; additive public mutation only.
